### PR TITLE
feat: add arithmetic expression parsing

### DIFF
--- a/examples/arith.vl
+++ b/examples/arith.vl
@@ -1,0 +1,4 @@
+{
+  scl a;
+  a = 2 + 3*4;   // should parse
+}

--- a/src/lexer/vlang.l
+++ b/src/lexer/vlang.l
@@ -22,6 +22,12 @@
 "}" { return '}'; }
 ";" { return ';'; }
 "=" { return '='; }
+"(" { return '('; }
+")" { return ')'; }
+"+" { return '+'; }
+"-" { return '-'; }
+"*" { return '*'; }
+"/" { return '/'; }
 
 .   { fprintf(stderr, "Unexpected character '%s' at line %d\n", yytext, yylineno); }
 %%

--- a/src/parser/vlang.y
+++ b/src/parser/vlang.y
@@ -10,6 +10,9 @@ extern int yylineno;
 %token SCL VEC IF LOOP PRINT
 %token IDENT INT_LIT
 
+%left '+' '-'
+%left '*' '/'
+
 %start Program
 
 %%
@@ -42,8 +45,13 @@ Assign    : IDENT '=' Exp ;
 
 /* expressions (minimal for now) */
 Exp       : INT_LIT
-          | IDENT
-          ;
+           | IDENT
+           | '(' Exp ')'
+           | Exp '+' Exp
+           | Exp '-' Exp
+           | Exp '*' Exp
+           | Exp '/' Exp
+           ;
 
 %%
 


### PR DESCRIPTION
## Summary
- parse arithmetic expressions with operator precedence and parentheses
- tokenize arithmetic operators and parentheses in lexer
- add arithmetic example

## Testing
- `make clean && make`
- `./generated/build/vlangc examples/arith.vl`


------
https://chatgpt.com/codex/tasks/task_e_689366d6f2708320b22ffc231d17c55e