### PR TITLE
Add vector literals and dot/index operators

### DIFF
--- a/examples/vec_ops.vl
+++ b/examples/vec_ops.vl
@@ -1,0 +1,6 @@
+{
+  vec v{3};
+  v = [1,2,3];
+  scl dp; dp = v @ v;
+  scl x;  x = v : 1;
+}

--- a/src/lexer/vlang.l
+++ b/src/lexer/vlang.l
@@ -28,6 +28,11 @@
 "-" { return '-'; }
 "*" { return '*'; }
 "/" { return '/'; }
+"[" { return '['; }
+"]" { return ']'; }
+"," { return ','; }
+"@" { return '@'; }
+":" { return ':'; }
 
 .   { fprintf(stderr, "Unexpected character '%s' at line %d\n", yytext, yylineno); }
 %%

--- a/src/parser/vlang.y
+++ b/src/parser/vlang.y
@@ -12,6 +12,7 @@ extern int yylineno;
 
 %left '+' '-'
 %left '*' '/'
+%left '@' ':'   /* highest */
 
 %start Program
 
@@ -51,7 +52,21 @@ Exp       : INT_LIT
            | Exp '-' Exp
            | Exp '*' Exp
            | Exp '/' Exp
+           | Exp '@' Exp
+           | Exp ':' Exp
+           | VecLit
            ;
+
+VecLit    : '[' IntListOpt ']';
+
+IntListOpt
+          : /* empty */
+          | IntList
+          ;
+
+IntList   : INT_LIT
+          | IntList ',' INT_LIT
+          ;
 
 %%
 


### PR DESCRIPTION
## Summary
- allow `[1,2,3]` vector literals in expressions
- support vector dot (`@`) and index (`:`) operators with highest precedence
- add example demonstrating vector operations

## Testing
- `make clean && make`
- `generated/build/vlangc examples/vec_ops.vl`


------
https://chatgpt.com/codex/tasks/task_e_6893756a07fc8320a8351992bfbf9aa3