### PR TITLE
Add print, if, and loop statements

### DIFF
--- a/examples/control.vl
+++ b/examples/control.vl
@@ -1,0 +1,5 @@
+{
+  scl a; a = 1 + 2;
+  print "sum": a;
+  if a { loop 2 { a = a + 1; } }
+}

--- a/src/lexer/vlang.l
+++ b/src/lexer/vlang.l
@@ -15,6 +15,8 @@
 "loop"                  { return LOOP; }
 "print"                 { return PRINT; }
 
+\"[^\n"]*\"         { return STRING_LIT; }
+
 [A-Za-z_][A-Za-z0-9_]*  { if (yyleng > 32) { fprintf(stderr, "Identifier too long at line %d\n", yylineno); } return IDENT; }
 [0-9]+                  { return INT_LIT; }
 

--- a/src/parser/vlang.y
+++ b/src/parser/vlang.y
@@ -7,7 +7,7 @@ extern int yylineno;
 %}
 
 /* tokens */
-%token SCL VEC IF LOOP PRINT
+%token SCL VEC PRINT IF LOOP STRING_LIT
 %token IDENT INT_LIT
 
 %left '+' '-'
@@ -34,7 +34,25 @@ StmtList  : Stmt
 Stmt      : ';'
           | Decl ';'
           | Assign ';'
+          | Print ';'
+          | If
+          | Loop
           ;
+
+Print     : PRINT STRING_LIT ':' PrintArgsOpt ;
+
+PrintArgsOpt
+          : /* empty */
+          | PrintArgs
+          ;
+
+PrintArgs : Exp
+          | PrintArgs ',' Exp
+          ;
+
+If        : IF Exp Block ;
+
+Loop      : LOOP Exp Block ;
 
 /* declarations */
 Decl      : SCL IDENT


### PR DESCRIPTION
## Summary
- extend parser with `print`, `if`, and `loop` statement rules and string literal token
- recognize string literals and new keywords in the lexer
- add `control.vl` example to exercise control flow parsing

## Testing
- `make`
- `./generated/build/vlangc examples/control.vl`


------
https://chatgpt.com/codex/tasks/task_e_68937b435338832093ed7953cc1a5107